### PR TITLE
Reduced Time Per badge (TPB)

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from dateutil import tz
 
 from roblox import Client
 
-USER_ID = "INSERT_RBLX_USERID"
+USER_ID = "2221466284"
 FILENAME = f"{USER_ID}_badges.json"
 
 client = Client()
@@ -28,7 +28,7 @@ async def grab_badges():
             for badge in badges_data["data"]:
                 awarded_date = await date_format(badge["id"])
                 badges.append({"badgeId": badge["id"], "badgeName": badge["name"], "dateAwarded": awarded_date})
-                await asyncio.sleep(2)
+                await asyncio.sleep(1)
             next_page_cursor = badges_data.get("nextPageCursor")
             params["cursor"] = next_page_cursor
             if not next_page_cursor:

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from dateutil import tz
 
 from roblox import Client
 
-USER_ID = "2221466284"
+USER_ID = "INSERT_RBLX_ID"
 FILENAME = f"{USER_ID}_badges.json"
 
 client = Client()
@@ -28,7 +28,7 @@ async def grab_badges():
             for badge in badges_data["data"]:
                 awarded_date = await date_format(badge["id"])
                 badges.append({"badgeId": badge["id"], "badgeName": badge["name"], "dateAwarded": awarded_date})
-                await asyncio.sleep(1)
+                await asyncio.sleep(0.5)
             next_page_cursor = badges_data.get("nextPageCursor")
             params["cursor"] = next_page_cursor
             if not next_page_cursor:


### PR DESCRIPTION
# Change
Due to Roblox's API request limitation, we unfortunately can't request badge-awarded dates at a constant rate without delay. However, through experimenting I've been able to limit how long we need to wait for a request. Instead of waiting 2 seconds it's now half a second.

### Example
If we have **__60 badges__**. 
| Total Badges | Before (2 seconds) | After (0.5 seconds) |
|--------|--------|--------|
| 60 badges | 120 seconds | 30 seconds|
| 120 badges | 240 seconds | 60 seconds |
| 500 badges | 1000 seconds | 250 seconds | 